### PR TITLE
port to Ogre 2.1 (and 2.0)

### DIFF
--- a/include/OgreOggISound.h
+++ b/include/OgreOggISound.h
@@ -511,7 +511,7 @@ namespace OgreOggSound
 			This will only be set if the sound was created through the plugin method
 			createMovableobject().
 		*/
-		inline Ogre::SceneManager* getSceneManager() const { return &mScnMan; }   
+		inline Ogre::SceneManager* getSceneManager() const { return mScnMan; }   
 
 		/** Sets a listener object to be notified of events.
 		@remarks
@@ -551,7 +551,12 @@ namespace OgreOggSound
 		@param scnMgr
 			SceneManager which create this sound
 		 */
-		OgreOggISound(const Ogre::String& name, const Ogre::SceneManager& scnMgr);
+		OgreOggISound(
+			const Ogre::String& name, Ogre::SceneManager* scnMgr
+			#if OGRE_VERSION_MAJOR == 2
+			, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
+			#endif
+		);
 		/** Superclass destructor.
 		 */
 		virtual ~OgreOggISound();
@@ -595,17 +600,30 @@ namespace OgreOggSound
 		@remarks
 			Overridden from MovableObject.
 		 */
-		virtual void _notifyAttached(Ogre::Node* node, bool isTagPoint=false);
+		virtual void _notifyAttached(
+			Ogre::Node* node
+			#if OGRE_VERSION_MAJOR == 1
+			, bool isTagPoint = false
+			#endif
+		);
+		#if OGRE_VERSION_MAJOR == 1
 		/** Notifys object its been moved
 		@remarks
 			Overridden from MovableObject.
 		 */
 		virtual void _notifyMoved(void);
+		#else
+		/** do nothing but need for derived from MovableObject
+		 */
+		virtual void _updateRenderQueue(Ogre::RenderQueue *queue, Ogre::Camera *camera, const Ogre::Camera *lodCamera);
+		#endif
+		#if OGRE_VERSION_MAJOR == 1 || OGRE_VERSION_MINOR == 0
 		/** Renderable callback
 		@remarks
 			Overridden function from MovableObject.
 		 */
 		virtual void visitRenderables(Ogre::Renderable::Visitor* visitor, bool debugRenderables);
+		#endif
 
 		/** Inits source object
 		@remarks
@@ -667,7 +685,7 @@ namespace OgreOggSound
 		/** Sound properties 
 		 */
 		ALuint mSource;					// OpenAL Source
-		Ogre::SceneManager& mScnMan;	// SceneManager reference for plugin registered sounds
+		Ogre::SceneManager* mScnMan;	// SceneManager pointer for plugin registered sounds
 		Ogre::uint8 mPriority;			// Priority assigned to source 
 		Ogre::Vector3 mPosition;		// 3D position
 		Ogre::Vector3 mDirection;		// 3D direction
@@ -690,7 +708,9 @@ namespace OgreOggSound
 		bool mGiveUpSource;				// Flag to indicate whether sound should release its source when stopped
 		bool mStream;					// Stream flag
 		bool mSourceRelative;			// Relative position flag
+		#if OGRE_VERSION_MAJOR == 1
 		bool mLocalTransformDirty;		// Transformation update flag
+		#endif
 		bool mPlayPosChanged;			// Flag indicating playback position has changed
 		bool mSeekable;					// Flag indicating seeking available
 		bool mTemporary;				// Flag indicating sound is temporary

--- a/include/OgreOggListener.h
+++ b/include/OgreOggListener.h
@@ -61,13 +61,31 @@ namespace OgreOggSound
 		@remarks
 			Creates a listener object to act as the ears of the user. 
 		 */
-		OgreOggListener(): mPosition(Ogre::Vector3::ZERO)
+		OgreOggListener(
+			#if OGRE_VERSION_MAJOR == 2
+			Ogre::IdType id, Ogre::SceneManager *scnMgr, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
+			#else
+			Ogre::SceneManager* scnMgr = NULL
+			#endif
+		): 
+			#if OGRE_VERSION_MAJOR == 2 && OGRE_VERSION_MINOR == 0
+				MovableObject(id, objMemMgr, renderQueueId),
+			#elif OGRE_VERSION_MAJOR == 2 && OGRE_VERSION_MINOR > 0
+				MovableObject(id, objMemMgr, scnMgr, renderQueueId),
+			#endif
+			  mPosition(Ogre::Vector3::ZERO)
 			, mVelocity(Ogre::Vector3::ZERO)
+			#if OGRE_VERSION_MAJOR == 1
 			, mLocalTransformDirty(false)
-			, mSceneMgr(0)
+			#endif
+			, mSceneMgr(scnMgr)
 		{
-			for (int i=0; i<6; ++i ) mOrientation[i]=0.f;	
+			for (int i=0; i<6; ++i ) mOrientation[i]=0.f;
 			mName = "OgreOggListener";
+			#if OGRE_VERSION_MAJOR == 2
+			setLocalAabb(Ogre::Aabb::BOX_NULL);
+			setQueryFlags(0);
+			#endif
 		};
 		/** Sets the position of the listener.
 		@remarks
@@ -153,28 +171,42 @@ namespace OgreOggSound
 			Overridden function from MovableObject.
 		 */
 		virtual void _updateRenderQueue(Ogre::RenderQueue *queue);
+		#if OGRE_VERSION_MAJOR == 1 || OGRE_VERSION_MINOR == 0
 		/** Renderable callback
 		@remarks
 			Overridden function from MovableObject.
 		 */
 		virtual void visitRenderables(Ogre::Renderable::Visitor* visitor, bool debugRenderables);
+		#endif
 		/** Attach callback
 		@remarks
 			Overridden function from MovableObject.
 		 */
-		virtual void _notifyAttached(Ogre::Node* node, bool isTagPoint=false);
+		virtual void _notifyAttached(
+			Ogre::Node* node
+			#if OGRE_VERSION_MAJOR == 1
+			, bool isTagPoint = false
+			#endif
+		);
+		#if OGRE_VERSION_MAJOR == 1
 		/** Moved callback
 		@remarks
 			Overridden function from MovableObject.
 		 */
 		virtual void _notifyMoved(void);
+		#else
+		/** do nothing but need for derived from MovableObject
+		 */
+		virtual void _updateRenderQueue(Ogre::RenderQueue *queue, Ogre::Camera *camera, const Ogre::Camera *lodCamera);
+		#endif
 		/** Returns scenemanager which created this listener.
 		 */
 		Ogre::SceneManager* getSceneManager() { return mSceneMgr; }
+		#if OGRE_VERSION_MAJOR == 1
 		/** Sets scenemanager which created this listener.
 		 */
 		void setSceneManager(Ogre::SceneManager& m) { mSceneMgr=&m; }
-		
+		#endif
 	private:
 
 #if OGGSOUND_THREADED
@@ -191,7 +223,11 @@ namespace OgreOggSound
 		Ogre::Vector3 mPosition;		// 3D position
 		Ogre::Vector3 mVelocity;		// 3D velocity
 		float mOrientation[6];			// 3D orientation
+		#if OGRE_VERSION_MAJOR == 2
+		Ogre::Quaternion mOrient;		// 3D orientation as Quaternion
+		#else
 		bool mLocalTransformDirty;		// Dirty transforms flag
+		#endif
 		Ogre::SceneManager* mSceneMgr;	// Creator 
 
 	};

--- a/include/OgreOggSoundFactory.h
+++ b/include/OgreOggSoundFactory.h
@@ -46,8 +46,13 @@ namespace OgreOggSound
 	{
 
 	protected:
-		Ogre::MovableObject* createInstanceImpl( const Ogre::String& name, const Ogre::NameValuePairList* params);
-
+		#if OGRE_VERSION_MAJOR == 2 && OGRE_VERSION_MINOR == 0
+			Ogre::MovableObject* createInstanceImpl(Ogre::IdType id, Ogre::ObjectMemoryManager *objectMemoryManager, const Ogre::NameValuePairList* params = 0);
+		#elif OGRE_VERSION_MAJOR == 2 && OGRE_VERSION_MINOR > 0
+			Ogre::MovableObject* createInstanceImpl(Ogre::IdType id, Ogre::ObjectMemoryManager *objectMemoryManager, Ogre::SceneManager* manager, const Ogre::NameValuePairList* params = 0);
+		#else
+			Ogre::MovableObject* createInstanceImpl(const Ogre::String& name, const Ogre::NameValuePairList* params);
+		#endif
 	public:
 		OgreOggSoundFactory() {}
 		~OgreOggSoundFactory() {}

--- a/include/OgreOggSoundManager.h
+++ b/include/OgreOggSoundManager.h
@@ -737,7 +737,7 @@ namespace OgreOggSound
 			parameters this function will create a static/streamed sound.
 			Each sound must have a unique name within the manager.
 			@param scnMgr
-				Reference to creator
+				pointer to creator
 			@param name 
 				Unique name of sound
 			@param file 
@@ -749,7 +749,20 @@ namespace OgreOggSound
 			@param preBuffer 
 				Flag indicating if a source should be attached at creation.
 		 */
-		OgreOggISound* _createSoundImpl(const Ogre::SceneManager& scnMgr, const std::string& name,const std::string& file, bool stream = false, bool loop = false, bool preBuffer=false, bool immediate=false);
+		
+		OgreOggISound* _createSoundImpl(
+			Ogre::SceneManager* scnMgr,
+			const std::string& name,
+			#if OGRE_VERSION_MAJOR == 2
+			Ogre::IdType id,
+			#endif
+			const std::string& file,
+			bool stream    = false,
+			bool loop      = false,
+			bool preBuffer = false,
+			bool immediate = false
+		);
+		
 		/** Implementation of sound loading
 		@param sound
 			sound pointer.

--- a/include/OgreOggSoundPrereqs.h
+++ b/include/OgreOggSoundPrereqs.h
@@ -69,7 +69,7 @@
 #	else
 #		define _OGGSOUND_EXPORT
 #	endif
-#elif OGRE_COMPILER == OGRE_COMPILER_GNUC
+#elif OGRE_COMPILER == OGRE_COMPILER_GNUC || OGRE_COMPILER == OGRE_COMPILER_CLANG
 #   if OGRE_PLATFORM == OGRE_PLATFORM_APPLE
 #		include <al.h>
 #		include <alc.h>

--- a/include/OgreOggStaticSound.h
+++ b/include/OgreOggStaticSound.h
@@ -81,7 +81,12 @@ namespace OgreOggSound
 		/**
 		 * Constructor
 		 */
-		OgreOggStaticSound(const Ogre::String& name, const Ogre::SceneManager& scnMgr);
+		OgreOggStaticSound(
+			const Ogre::String& name, Ogre::SceneManager* scnMgr
+			#if OGRE_VERSION_MAJOR == 2
+			, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
+			#endif
+		);
 		/**
 		 * Destructor
 		 */

--- a/include/OgreOggStaticWavSound.h
+++ b/include/OgreOggStaticWavSound.h
@@ -81,7 +81,12 @@ namespace OgreOggSound
 		/**
 		 * Constructor
 		 */
-		OgreOggStaticWavSound(const Ogre::String& name,const Ogre::SceneManager& scnMgr);
+		OgreOggStaticWavSound(
+			const Ogre::String& name, Ogre::SceneManager* scnMgr
+			#if OGRE_VERSION_MAJOR == 2
+			, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
+			#endif
+		);
 		/**
 		 * Destructor
 		 */

--- a/include/OgreOggStreamSound.h
+++ b/include/OgreOggStreamSound.h
@@ -92,7 +92,12 @@ namespace OgreOggSound
 			@param
 				name Unique name for sound.	
 		 */
-		OgreOggStreamSound(const Ogre::String& name, const Ogre::SceneManager& scnMgr);
+		OgreOggStreamSound(
+			const Ogre::String& name, Ogre::SceneManager* scnMgr
+			#if OGRE_VERSION_MAJOR == 2
+			, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
+			#endif
+		);
 		/**
 		 * Destructor
 		 */

--- a/include/OgreOggStreamWavSound.h
+++ b/include/OgreOggStreamWavSound.h
@@ -90,7 +90,12 @@ namespace OgreOggSound
 			@param
 				name Unique name for sound.	
 		 */
-		OgreOggStreamWavSound(const Ogre::String& name, const Ogre::SceneManager& scnMgr);
+		OgreOggStreamWavSound(
+			const Ogre::String& name, Ogre::SceneManager* scnMgr
+			#if OGRE_VERSION_MAJOR == 2
+			, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
+			#endif
+		);
 		/**
 		 * Destructor
 		 */

--- a/src/OgreOggISound.cpp
+++ b/src/OgreOggISound.cpp
@@ -74,7 +74,17 @@ namespace OgreOggSound
 	}
 
 	/*/////////////////////////////////////////////////////////////////*/
-	OgreOggISound::OgreOggISound(const Ogre::String& name, const Ogre::SceneManager& scnMgr) : 
+	OgreOggISound::OgreOggISound(
+		const Ogre::String& name, Ogre::SceneManager* scnMgr
+		#if OGRE_VERSION_MAJOR == 2
+		, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
+		#endif
+	) : 
+	#if OGRE_VERSION_MAJOR == 2 && OGRE_VERSION_MINOR == 0
+	MovableObject(id, objMemMgr, renderQueueId),
+	#elif OGRE_VERSION_MAJOR == 2 && OGRE_VERSION_MINOR > 0
+	MovableObject(id, objMemMgr, scnMgr, renderQueueId),
+	#endif
 	 mName(name)
 	,mSource(0) 
 	,mLoop(false) 
@@ -104,11 +114,13 @@ namespace OgreOggSound
 	,mPlayPosChanged(false)  
 	,mPlayPos(0.f) 
 	,mPriority(0)
-	,mScnMan(const_cast<Ogre::SceneManager&>(scnMgr))
+	,mScnMan(scnMgr)
 	,mAudioOffset(0)
 	,mAudioEnd(0)
 	,mLoopOffset(0)
+	#if OGRE_VERSION_MAJOR == 1
 	,mLocalTransformDirty(true)
+	#endif
 	,mDisable3D(false)
 	,mSeekable(true)
 	,mSourceRelative(false)
@@ -123,6 +135,10 @@ namespace OgreOggSound
 		mOggCallbacks.seek_func	= OOSStreamSeek;
 		mOggCallbacks.tell_func	= OOSStreamTell;
 		mBuffers.setNull();
+		#if OGRE_VERSION_MAJOR == 2
+		setLocalAabb(Ogre::Aabb::BOX_NULL);
+		setQueryFlags(0);
+		#endif
 	}
 	/*/////////////////////////////////////////////////////////////////*/
 	OgreOggISound::~OgreOggISound() 
@@ -241,13 +257,21 @@ namespace OgreOggSound
 		mPosition.x = posx;
 		mPosition.y = posy;
 		mPosition.z = posz;	
+		#if OGRE_VERSION_MAJOR == 1
 		mLocalTransformDirty = true;
+		#else
+		alSource3f(mSource, AL_POSITION, mPosition.x, mPosition.y, mPosition.z);
+		#endif
 	}
 	/*/////////////////////////////////////////////////////////////////*/
 	void OgreOggISound::setPosition(const Ogre::Vector3 &pos)
 	{
 		mPosition = pos;   
+		#if OGRE_VERSION_MAJOR == 1
 		mLocalTransformDirty = true;
+		#else
+		alSource3f(mSource, AL_POSITION, mPosition.x, mPosition.y, mPosition.z);
+		#endif
 	}
 	/*/////////////////////////////////////////////////////////////////*/
 	void OgreOggISound::setDirection(float dirx, float diry, float dirz)
@@ -255,13 +279,21 @@ namespace OgreOggSound
 		mDirection.x = dirx;
 		mDirection.y = diry;
 		mDirection.z = dirz;
+		#if OGRE_VERSION_MAJOR == 1
 		mLocalTransformDirty = true;
+		#else
+		alSource3f(mSource, AL_DIRECTION, mDirection.x, mDirection.y, mDirection.z);
+		#endif
 	}
 	/*/////////////////////////////////////////////////////////////////*/
 	void OgreOggISound::setDirection(const Ogre::Vector3 &dir)
 	{
 		mDirection = dir;  
+		#if OGRE_VERSION_MAJOR == 1
 		mLocalTransformDirty = true;
+		#else
+		alSource3f(mSource, AL_DIRECTION, mDirection.x, mDirection.y, mDirection.z);
+		#endif
 	}
 	/*/////////////////////////////////////////////////////////////////*/
 	void OgreOggISound::setVelocity(float velx, float vely, float velz)
@@ -655,6 +687,7 @@ namespace OgreOggSound
 	/*/////////////////////////////////////////////////////////////////*/
 	void OgreOggISound::update(float fTime)
 	{
+		#if OGRE_VERSION_MAJOR == 1
 		if (mLocalTransformDirty)
 		{
 			if (!mDisable3D && mParentNode)
@@ -669,7 +702,22 @@ namespace OgreOggSound
 				alSource3f(mSource, AL_DIRECTION, mDirection.x, mDirection.y, mDirection.z);
 				mLocalTransformDirty = false;
 			}
-		}	
+		}
+		#else
+		if (!mDisable3D && mParentNode && mSource != AL_NONE) {
+			Ogre::Vector3    newPos    = mParentNode->_getDerivedPosition();
+			if (newPos != mPosition) {
+				mPosition = newPos;
+				alSource3f(mSource, AL_POSITION, mPosition.x, mPosition.y, mPosition.z);
+			}
+			
+			Ogre::Vector3    newDir = -mParentNode->_getDerivedOrientation().zAxis();
+			if (newDir != mDirection) {
+				mDirection = newDir;
+				alSource3f(mSource, AL_DIRECTION, mDirection.x, mDirection.y, mDirection.z);
+			}
+		}
+		#endif
 
 		_updateFade(fTime);
 	}
@@ -695,15 +743,29 @@ namespace OgreOggSound
 		return;
 	}
 	/*/////////////////////////////////////////////////////////////////*/
-	void OgreOggISound::_notifyAttached(Ogre::Node* node, bool isTagPoint)
+	void OgreOggISound::_notifyAttached(
+		Ogre::Node* node
+		#if OGRE_VERSION_MAJOR == 1
+		, bool isTagPoint
+		#endif
+	)
 	{
 		// Call base class notify
-		Ogre::MovableObject::_notifyAttached(node, isTagPoint);
+		Ogre::MovableObject::_notifyAttached(
+			node
+			#if OGRE_VERSION_MAJOR == 1
+			, isTagPoint
+			#endif
+		);
 
 		// Immediately set position/orientation when attached
 		if (mParentNode)
 		{
+			#if OGRE_VERSION_MAJOR == 1
 			mPosition = mParentNode->_getDerivedPosition();
+			#else
+			mPosition = mParentNode->_getDerivedPositionUpdated();
+			#endif
 			mDirection = -mParentNode->_getDerivedOrientation().zAxis();
 		}
 
@@ -717,6 +779,7 @@ namespace OgreOggSound
 		return;
 	}
 	/*/////////////////////////////////////////////////////////////////*/
+	#if OGRE_VERSION_MAJOR == 1
 	void OgreOggISound::_notifyMoved(void) 
 	{ 
 		// Call base class notify
@@ -724,9 +787,15 @@ namespace OgreOggSound
 
 		mLocalTransformDirty=true; 
 	}
+	#else
+	void OgreOggISound::_updateRenderQueue(Ogre::RenderQueue *queue, Ogre::Camera *camera, const Ogre::Camera *lodCamera) {
+	}
+	#endif
+	#if OGRE_VERSION_MAJOR == 1 || OGRE_VERSION_MINOR == 0
 	/*/////////////////////////////////////////////////////////////////*/
 	void OgreOggISound::visitRenderables(Ogre::Renderable::Visitor* visitor, bool debugRenderables)
 	{
 		return;
 	}
+	#endif
 }

--- a/src/OgreOggListener.cpp
+++ b/src/OgreOggListener.cpp
@@ -127,6 +127,7 @@ namespace OgreOggSound
 		boost::recursive_mutex::scoped_lock lock(mMutex);
 #	endif
 #endif
+		mOrient = q;
 		Ogre::Vector3 vDirection = q.zAxis();
 		Ogre::Vector3 vUp = q.yAxis();
 
@@ -155,15 +156,29 @@ namespace OgreOggSound
 	/*/////////////////////////////////////////////////////////////////*/
 	void OgreOggListener::update()
 	{
+		#if OGRE_VERSION_MAJOR == 1
 		if(mLocalTransformDirty)
 		{
 			if ( mParentNode )
 			{
 				setPosition(mParentNode->_getDerivedPosition());
-				setOrientation(mParentNode->_getDerivedOrientation());			 
+				setOrientation(mParentNode->_getDerivedOrientation());
 			}
 			mLocalTransformDirty=false;
 		}
+		#else
+		if (mParentNode) {
+			Ogre::Vector3    newPos    = mParentNode->_getDerivedPosition();
+			if (newPos != mPosition) {
+				setPosition(newPos);
+			}
+			
+			Ogre::Quaternion newOrient = mParentNode->_getDerivedOrientation();
+			if (newOrient != mOrient) {
+				setOrientation(newOrient);
+			}
+		}
+		#endif
 	}
 	/*/////////////////////////////////////////////////////////////////*/
 	const Ogre::AxisAlignedBox& OgreOggListener::getBoundingBox(void) const
@@ -181,32 +196,49 @@ namespace OgreOggSound
 	{
 		return;
 	}
+	#if OGRE_VERSION_MAJOR == 1 || OGRE_VERSION_MINOR == 0
 	/*/////////////////////////////////////////////////////////////////*/
 	void OgreOggListener::visitRenderables(Ogre::Renderable::Visitor* visitor, bool debugRenderables)
 	{
 		return;
 	}
+	#endif
 	/*/////////////////////////////////////////////////////////////////*/
 	const Ogre::String& OgreOggListener::getMovableType(void) const
 	{
 		return OgreOggSoundFactory::FACTORY_TYPE_NAME;
 	}
 	/*/////////////////////////////////////////////////////////////////*/
-	void OgreOggListener::_notifyAttached(Ogre::Node* node, bool isTagPoint)
+	void OgreOggListener::_notifyAttached(
+		Ogre::Node* node
+		#if OGRE_VERSION_MAJOR == 1
+		, bool isTagPoint
+		#endif
+	)
 	{
 		// Call base class notify
-		Ogre::MovableObject::_notifyAttached(node, isTagPoint);
+		Ogre::MovableObject::_notifyAttached(
+			node
+			#if OGRE_VERSION_MAJOR == 1
+			, isTagPoint
+			#endif
+		);
 
 		// Immediately set position/orientation when attached
 		if (mParentNode)
 		{
+			#if OGRE_VERSION_MAJOR == 1
 			setPosition(mParentNode->_getDerivedPosition());
+			#else
+			setPosition(mParentNode->_getDerivedPositionUpdated());
+			#endif
 			setOrientation(mParentNode->_getDerivedOrientation());
 		}
 
 		return;
 	}
 	/*/////////////////////////////////////////////////////////////////*/
+	#if OGRE_VERSION_MAJOR == 1
 	void OgreOggListener::_notifyMoved(void) 
 	{ 
 		// Call base class notify
@@ -214,6 +246,8 @@ namespace OgreOggSound
 
 		mLocalTransformDirty=true; 
 	}
+	#else
+	void OgreOggListener::_updateRenderQueue(Ogre::RenderQueue *queue, Ogre::Camera *camera, const Ogre::Camera *lodCamera) {
+	}
+	#endif
 }
-
-	

--- a/src/OgreOggListener.cpp
+++ b/src/OgreOggListener.cpp
@@ -127,7 +127,9 @@ namespace OgreOggSound
 		boost::recursive_mutex::scoped_lock lock(mMutex);
 #	endif
 #endif
+		#if OGRE_VERSION_MAJOR == 2
 		mOrient = q;
+		#endif
 		Ogre::Vector3 vDirection = q.zAxis();
 		Ogre::Vector3 vUp = q.yAxis();
 

--- a/src/OgreOggStaticSound.cpp
+++ b/src/OgreOggStaticSound.cpp
@@ -39,7 +39,17 @@ namespace OgreOggSound
 {
 
 	/*/////////////////////////////////////////////////////////////////*/
-	OgreOggStaticSound::OgreOggStaticSound(const Ogre::String& name, const Ogre::SceneManager& scnMgr) : OgreOggISound(name, scnMgr)
+	OgreOggStaticSound::OgreOggStaticSound(
+		const Ogre::String& name, Ogre::SceneManager* scnMgr
+		#if OGRE_VERSION_MAJOR == 2
+		, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
+		#endif
+	) : OgreOggISound(
+		name, scnMgr
+		#if OGRE_VERSION_MAJOR == 2
+		, id, objMemMgr, renderQueueId
+		#endif
+	)
 	,mVorbisInfo(0)
 	,mVorbisComment(0)
 	,mPreviousOffset(0)

--- a/src/OgreOggStaticWavSound.cpp
+++ b/src/OgreOggStaticWavSound.cpp
@@ -39,7 +39,17 @@ namespace OgreOggSound
 {
 
 	/*/////////////////////////////////////////////////////////////////*/
-			OgreOggStaticWavSound::OgreOggStaticWavSound(const Ogre::String& name,const Ogre::SceneManager& scnMgr) : OgreOggISound(name, scnMgr)
+	OgreOggStaticWavSound::OgreOggStaticWavSound(
+		const Ogre::String& name, Ogre::SceneManager* scnMgr
+		#if OGRE_VERSION_MAJOR == 2
+		, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
+		#endif
+	) : OgreOggISound(
+			name, scnMgr
+			#if OGRE_VERSION_MAJOR == 2
+			, id, objMemMgr, renderQueueId
+			#endif
+		)
 		,mAudioName("")
 		,mPreviousOffset(0)
 		{
@@ -49,7 +59,7 @@ namespace OgreOggSound
 			mBuffers.bind(new BufferList(1, AL_NONE));
 		}
 	/*/////////////////////////////////////////////////////////////////*/
-			OgreOggStaticWavSound::~OgreOggStaticWavSound()
+	OgreOggStaticWavSound::~OgreOggStaticWavSound()
 	{
 		// Notify listener
 		if ( mSoundListener ) mSoundListener->soundDestroyed(this);

--- a/src/OgreOggStreamSound.cpp
+++ b/src/OgreOggStreamSound.cpp
@@ -38,7 +38,17 @@
 namespace OgreOggSound
 {
 	/*/////////////////////////////////////////////////////////////////*/
-	OgreOggStreamSound::OgreOggStreamSound(const Ogre::String& name, const Ogre::SceneManager& scnMgr) : OgreOggISound(name, scnMgr)
+	OgreOggStreamSound::OgreOggStreamSound(
+		const Ogre::String& name, Ogre::SceneManager* scnMgr
+		#if OGRE_VERSION_MAJOR == 2
+		, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
+		#endif
+	) : OgreOggISound(
+		name, scnMgr
+		#if OGRE_VERSION_MAJOR == 2
+		, id, objMemMgr, renderQueueId
+		#endif
+	)
 	,mVorbisInfo(0)
 	,mVorbisComment(0)
 	,mStreamEOF(false)

--- a/src/OgreOggStreamWavSound.cpp
+++ b/src/OgreOggStreamWavSound.cpp
@@ -39,7 +39,17 @@ namespace OgreOggSound
 {
 
 	/*/////////////////////////////////////////////////////////////////*/
-	OgreOggStreamWavSound::OgreOggStreamWavSound(const Ogre::String& name, const Ogre::SceneManager& scnMgr) : OgreOggISound(name, scnMgr)
+	OgreOggStreamWavSound::OgreOggStreamWavSound(
+		const Ogre::String& name, Ogre::SceneManager* scnMgr
+		#if OGRE_VERSION_MAJOR == 2
+		, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
+		#endif
+	) : OgreOggISound(
+		name, scnMgr
+		#if OGRE_VERSION_MAJOR == 2
+		, id, objMemMgr, renderQueueId
+		#endif
+	)
 	, mLoopOffsetBytes(0)
 	, mStreamEOF(false)
 	, mLastOffset(0.f)


### PR DESCRIPTION
Adding support for Ogre 2.0 and 2.1.

Patch used #if OGRE_VERSION_MAJOR == 2 so it shouldn't break Ogre 1.x build.
Patch makes some minor changes in internal interface (protected methods and members).