### PR TITLE
add addSoundToResume() to OgreOggSoundManager

### DIFF
--- a/include/OgreOggSoundManager.h
+++ b/include/OgreOggSoundManager.h
@@ -240,6 +240,13 @@ namespace OgreOggSound
 		/** Un mutes all sounds.
 		 */
 		inline void unmuteAllSounds() { setMasterVolume(mOrigVolume); }
+		/** Add single sound to list of sounds resumed on resumeAllPausedSounds call.
+		@remarks
+			Do not pause sound or check play/pause state. Only add to list of sounds to resume.
+			@param sound 
+				Sound pointer.
+		 */
+		void addSoundToResume(OgreOggISound* sound);
 		/** Resumes all previously playing sounds.
 		 */
 		void resumeAllPausedSounds();

--- a/src/OgreOggSoundManager.cpp
+++ b/src/OgreOggSoundManager.cpp
@@ -2231,6 +2231,12 @@ namespace OgreOggSound
 		}
 	}
 	/*/////////////////////////////////////////////////////////////////*/
+	void OgreOggSoundManager::addSoundToResume(OgreOggISound* sound)
+	{
+		// Add to list to allow resuming
+		mPausedSounds.push_back(sound);
+	}
+	/*/////////////////////////////////////////////////////////////////*/
 	void OgreOggSoundManager::_resumeAllPausedSoundsImpl()
 	{
 		if (mPausedSounds.empty()) return;


### PR DESCRIPTION
addSoundToResume() add single sound to list of sound to resume
on resumeAllPausedSounds() call. This allow easy creating paused
sound (while loading scene), that will be resumed by single call
after finished scene creating.