### PR TITLE
OgreOggStreamBufferSound for input sound from other systems/plugins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ SET (HEADER_FILES
     include/OgreOggSoundRecord.h
     include/OgreOggStaticSound.h
     include/OgreOggStaticWavSound.h
+    include/OgreOggStreamBufferSound.h
     include/OgreOggStreamSound.h
     include/OgreOggStreamWavSound.h
 )
@@ -32,6 +33,7 @@ SET (SOURCE_FILES
     src/OgreOggSoundRecord.cpp
     src/OgreOggStaticSound.cpp
     src/OgreOggStaticWavSound.cpp
+    src/OgreOggStreamBufferSound.cpp
     src/OgreOggStreamSound.cpp
     src/OgreOggStreamWavSound.cpp
 )

--- a/include/OgreOggSound.h
+++ b/include/OgreOggSound.h
@@ -41,6 +41,7 @@
 #include "OgreOggStaticWavSound.h"
 #include "OgreOggStreamSound.h"
 #include "OgreOggStreamWavSound.h"
+#include "OgreOggStreamBufferSound.h"
 #include "OgreOggSoundRecord.h"
 #include "OgreOggSoundFactory.h"
 #include "OgreOggSoundManager.h"

--- a/include/OgreOggSoundManager.h
+++ b/include/OgreOggSoundManager.h
@@ -185,7 +185,7 @@ namespace OgreOggSound
 			@param name 
 				Unique name of sound
 			@param file 
-				Audio file path string
+				Audio file path string or "BUFFER" for memory buffer sound (@ref OgreBufferStreamSound)
 			@param stream 
 				Flag indicating if the sound sound be streamed.
 			@param loop 
@@ -741,7 +741,7 @@ namespace OgreOggSound
 			@param name 
 				Unique name of sound
 			@param file 
-				Audio file path string
+				Audio file path string or "BUFFER" for memory buffer sound (@ref OgreBufferStreamSound)
 			@param stream 
 				Flag indicating if the sound sound be streamed.
 			@param loop 

--- a/include/OgreOggStreamBufferSound.h
+++ b/include/OgreOggStreamBufferSound.h
@@ -1,0 +1,153 @@
+/**
+* @file OgreOggStreamBufferSound.h
+* @author  Ian Stangoe
+* @version v1.26
+*
+* @section LICENSE
+* 
+* This source file is part of OgreOggSound, an OpenAL wrapper library for   
+* use with the Ogre Rendering Engine.										 
+*                                                                           
+* Copyright (c) 2013 Ian Stangoe
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE. 
+*
+* @section DESCRIPTION
+* 
+* Implements methods for creating/using a streamed ogg sound
+*/
+
+#pragma once
+
+#define NOT_IN_USE throw std::logic_error("not in use");
+
+#include "OgreOggSoundPrereqs.h"
+#include "OgreOggISound.h"
+
+namespace OgreOggSound
+{
+	//! A single streaming sound (OGG)
+	/** Handles playing a sound from an ogg stream.
+	*/
+	class _OGGSOUND_EXPORT OgreOggStreamBufferSound : public OgreOggISound
+	{
+
+	public:
+
+		/** Sets the position of the playback cursor in seconds
+		@param seconds
+			Play position in seconds 
+		 */
+		void setPlayPosition(float seconds) {}
+		/** Gets the position of the playback cursor in seconds
+		 */
+		float getPlayPosition() const { return mPlayPos; }
+		/** Sets the source to use for playback.
+		@remarks
+			Sets the source object this sound will use to queue buffers onto
+			for playback. Also handles refilling buffers and queuing up.
+			@param
+				src Source id.
+		 */
+		void setSource(ALuint& src);
+		/** Returns whether sound is mono
+		*/
+		bool isMono();
+		/** Set format and sampling frenquency
+		 */
+		void setFormat(ALenum format, int freq);
+		/** Insert sound data buffor
+		 */
+		void insertData(char* data, size_t dataLen);
+
+	protected:
+
+		/** Constructor
+		@remarks
+			Creates a streamed sound object for playing audio directly from
+			a file stream.
+			@param
+				name Unique name for sound.	
+		 */
+		OgreOggStreamBufferSound(
+			const Ogre::String& name, Ogre::SceneManager* scnMgr
+			#if OGRE_VERSION_MAJOR == 2
+			, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
+			#endif
+		);
+		/**
+		 * Destructor
+		 */
+		~OgreOggStreamBufferSound();
+		/** Opens audio file.
+		@remarks
+			Opens a specified file and checks validity. Reads first chunks
+			of audio data into buffers.
+			@param
+				file path string
+		 */
+		void _openImpl(Ogre::DataStreamPtr& fileStream) { NOT_IN_USE }
+		/** Stops playing sound.
+		@remarks
+			Stops playing audio immediately and resets playback. 
+			If specified to do so its source will be released also.
+		*/
+		void _stopImpl();
+		/** Pauses sound.
+		@remarks
+			Pauses playback on the source.
+		 */
+		void _pauseImpl();
+		/** Plays the sound.
+		@remarks
+			Begins playback of all buffers queued on the source. If a
+			source hasn't been setup yet it is requested and initialised
+			within this call.
+		 */
+		void _playImpl();
+		/** Updates the data buffers with sound information.
+		@remarks
+			This function refills processed buffers with audio data from
+			the stream, it automatically handles looping if set.
+		 */
+		void _updateAudioBuffers();
+		/** Prefills buffers with audio data.
+		@remarks
+			Loads audio data from the stream into the predefined data
+			buffers and queues them onto the source ready for playback.
+		 */
+		void _prebuffer() { NOT_IN_USE }
+		/** Calculates buffer size and format.
+		@remarks
+			Calculates a block aligned buffer size of 250ms using
+			sounds properties
+		 */
+		bool _queryBufferInfo() { NOT_IN_USE }
+		/** Releases buffers and OpenAL objects.
+		@remarks
+			Cleans up this sounds OpenAL objects, including buffers
+			and file pointers ready for destruction.
+		 */
+		void _release();
+
+		int mFreq;
+		std::list<ALuint> mAlBuffers;
+		friend class OgreOggSoundManager;
+	};
+}

--- a/include/OgreOggStreamBufferSound.h
+++ b/include/OgreOggStreamBufferSound.h
@@ -35,8 +35,6 @@
 
 #pragma once
 
-#define NOT_IN_USE throw std::logic_error("not in use");
-
 #include "OgreOggSoundPrereqs.h"
 #include "OgreOggISound.h"
 
@@ -74,7 +72,7 @@ namespace OgreOggSound
 		void setFormat(ALenum format, int freq);
 		/** Insert sound data buffor
 		 */
-		void insertData(char* data, size_t dataLen);
+		void insertData(char* data, size_t dataLen, bool start = true);
 
 	protected:
 
@@ -102,7 +100,7 @@ namespace OgreOggSound
 			@param
 				file path string
 		 */
-		void _openImpl(Ogre::DataStreamPtr& fileStream) { NOT_IN_USE }
+		void _openImpl(Ogre::DataStreamPtr& fileStream) {}
 		/** Stops playing sound.
 		@remarks
 			Stops playing audio immediately and resets playback. 
@@ -132,13 +130,13 @@ namespace OgreOggSound
 			Loads audio data from the stream into the predefined data
 			buffers and queues them onto the source ready for playback.
 		 */
-		void _prebuffer() { NOT_IN_USE }
+		void _prebuffer() {}
 		/** Calculates buffer size and format.
 		@remarks
 			Calculates a block aligned buffer size of 250ms using
 			sounds properties
 		 */
-		bool _queryBufferInfo() { NOT_IN_USE }
+		bool _queryBufferInfo() {}
 		/** Releases buffers and OpenAL objects.
 		@remarks
 			Cleans up this sounds OpenAL objects, including buffers

--- a/src/OgreOggStreamBufferSound.cpp
+++ b/src/OgreOggStreamBufferSound.cpp
@@ -1,0 +1,212 @@
+/**
+* @file OgreOggStreamBufferSound.cpp
+* @author  Ian Stangoe
+* @version v1.26
+*
+* @section LICENSE
+* 
+* This source file is part of OgreOggSound, an OpenAL wrapper library for   
+* use with the Ogre Rendering Engine.										 
+*                                                                           
+* Copyright (c) 2013 Ian Stangoe
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.  
+*
+*/
+
+#include "OgreOggStreamBufferSound.h"
+#include <string>
+#include <iostream>
+#include "OgreOggSound.h"
+
+namespace OgreOggSound
+{
+
+	/*/////////////////////////////////////////////////////////////////*/
+	OgreOggStreamBufferSound::OgreOggStreamBufferSound(
+		const Ogre::String& name, Ogre::SceneManager* scnMgr
+		#if OGRE_VERSION_MAJOR == 2
+		, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
+		#endif
+	) : OgreOggISound(
+		name, scnMgr
+		#if OGRE_VERSION_MAJOR == 2
+		, id, objMemMgr, renderQueueId
+		#endif
+	)
+		,mFreq(0)
+	{
+		mStream=false;
+	}
+	/*/////////////////////////////////////////////////////////////////*/
+	OgreOggStreamBufferSound::~OgreOggStreamBufferSound()
+	{		
+		// Notify listener
+		if ( mSoundListener ) mSoundListener->soundDestroyed(this);
+
+		_release();
+	}
+	/*/////////////////////////////////////////////////////////////////*/
+	void OgreOggStreamBufferSound::_release()
+	{
+		ALuint src=AL_NONE;
+		setSource(src);
+		mPlayPos = 0.f;
+	}
+	/*/////////////////////////////////////////////////////////////////*/
+	void OgreOggStreamBufferSound::setSource(ALuint& src)
+	{
+		if (src!=AL_NONE)
+		{
+			// Attach new source
+			mSource=src;
+
+			// Load audio data onto source
+			_prebuffer();
+
+			// Init source properties
+			_initSource();
+		}
+		else
+		{
+			// Validity check
+			if ( mSource!=AL_NONE )
+			{
+				// Need to stop sound BEFORE unqueuing
+				alSourceStop(mSource);
+
+				// Unqueue buffer
+				alSourcei(mSource, AL_BUFFER, 0);
+			}
+
+			// Attach new source
+			mSource=src;
+
+			// Cancel initialisation
+			mInitialised = false;
+		}
+	}
+	/*/////////////////////////////////////////////////////////////////*/
+	bool OgreOggStreamBufferSound::isMono()
+	{
+		if ( !mInitialised ) return false;
+		return ( (mFormat==AL_FORMAT_MONO16) || (mFormat==AL_FORMAT_MONO8) );
+	}
+	/*/////////////////////////////////////////////////////////////////*/
+	void OgreOggStreamBufferSound::setFormat(ALenum format, int freq)
+	{
+		mFormat = format;
+		mFreq = freq;
+		mInitialised = true;
+	}
+	/*/////////////////////////////////////////////////////////////////*/
+	void OgreOggStreamBufferSound::insertData(char* data, size_t dataLen)
+	{
+		ALuint buffID;
+		alGenBuffers(1, &buffID);
+		alBufferData(buffID, mFormat, data, dataLen, mFreq);
+		alSourceQueueBuffers(mSource, 1, &buffID);
+		mAlBuffers.push_back(buffID);
+	}
+	/*/////////////////////////////////////////////////////////////////*/
+	void OgreOggStreamBufferSound::_pauseImpl()
+	{
+		assert(mState != SS_DESTROYED);
+
+		if ( mSource==AL_NONE ) return;
+
+		alSourcePause(mSource);
+		mState = SS_PAUSED;
+
+		// Notify listener
+		if (mSoundListener) 
+			mSoundListener->soundPaused(this);
+	}
+	/*/////////////////////////////////////////////////////////////////*/
+	void OgreOggStreamBufferSound::_playImpl()
+	{
+		assert(mState != SS_DESTROYED);
+
+		if(isPlaying())
+			return;
+
+		if (mSource == AL_NONE)
+			if ( !OgreOggSoundManager::getSingleton()._requestSoundSource(this) )
+				return;
+
+		alSourcePlay(mSource);
+		mState = SS_PLAYING;
+
+		// Notify listener
+		if (mSoundListener) 
+			mSoundListener->soundPlayed(this);
+	}
+	/*/////////////////////////////////////////////////////////////////*/
+	void OgreOggStreamBufferSound::_stopImpl()
+	{
+		assert(mState != SS_DESTROYED);
+
+		if ( mSource==AL_NONE || isStopped() ) return;
+
+		alSourceStop(mSource);
+		alSourceRewind(mSource);
+		mState = SS_STOPPED;
+
+		// Notify listener
+		if (mSoundListener) mSoundListener->soundStopped(this);
+
+		// Mark for destruction
+		if (mTemporary)
+		{
+			mState = SS_DESTROYED;
+			OgreOggSoundManager::getSingletonPtr()->_destroyTemporarySound(this);
+		}
+		// Give up source immediately if specfied
+		else if (mGiveUpSource) 
+			OgreOggSoundManager::getSingleton()._releaseSoundSource(this);
+	}
+	/*/////////////////////////////////////////////////////////////////*/
+	void OgreOggStreamBufferSound::_updateAudioBuffers()
+	{
+		if (!isPlaying())
+			return;
+
+		ALenum state;
+		alGetSourcei(mSource, AL_SOURCE_STATE, &state);
+
+		if (state == AL_STOPPED)
+		{
+			stop();
+
+			// Finished callback
+			if ( mSoundListener ) 
+				mSoundListener->soundFinished(this);
+		}
+
+		int processed;
+		alGetSourcei(mSource, AL_BUFFERS_PROCESSED, &processed);
+		while(processed--)
+		{
+			ALuint buff = mAlBuffers.front();
+			mAlBuffers.pop_front();
+			alSourceUnqueueBuffers(mSource, 1, &buff);
+			alDeleteBuffers(1, &buff);
+		}
+	}
+}


### PR DESCRIPTION
Simple input from memory buffer instead of file. This input type is need for integration OgreOggSound with sound creating/receiving module (e.g. OgreVideoPlugin / TheoraPlayer).

Simple usage example for integration with OgreVideoPlugin:
https://github.com/rpaciorek/ogre-video-oggsound/blob/master/OgreOggSoundInterface.h